### PR TITLE
fix property mismatch between _language and language

### DIFF
--- a/tmdbapis/tmdb.py
+++ b/tmdbapis/tmdb.py
@@ -58,7 +58,7 @@ class TMDbAPIs:
             v4_account_id (str): TMDb V4 Account ID.
             v4_access_token (str):  TMDb V4 Access Token.
     """
-    def __init__(self, apikey: str, session_id: Optional[str] = None, v4_access_token: Optional[str] = None, language = None, session: Optional[Session] = None):
+    def __init__(self, apikey: str, session_id: Optional[str] = None, v4_access_token: Optional[str] = None, language: Optional[str] = None, session: Optional[Session] = None):
         self._session = Session() if session is None else session
         self._api4 = API4(v4_access_token, session=self._session) if v4_access_token else None
         self._api = API3(apikey, session_id=session_id, api4=self._api4, session=self._session, validate=False)

--- a/tmdbapis/tmdb.py
+++ b/tmdbapis/tmdb.py
@@ -58,8 +58,7 @@ class TMDbAPIs:
             v4_account_id (str): TMDb V4 Account ID.
             v4_access_token (str):  TMDb V4 Access Token.
     """
-    def __init__(self, apikey: str, session_id: Optional[str] = None, v4_access_token: Optional[str] = None, language="en", session: Optional[Session] = None):
-        self._language = None
+    def __init__(self, apikey: str, session_id: Optional[str] = None, v4_access_token: Optional[str] = None, language = None, session: Optional[Session] = None):
         self._session = Session() if session is None else session
         self._api4 = API4(v4_access_token, session=self._session) if v4_access_token else None
         self._api = API3(apikey, session_id=session_id, api4=self._api4, session=self._session, validate=False)
@@ -201,14 +200,14 @@ class TMDbAPIs:
 
     @property
     def language(self):
-        return self._language
+        return self.language
 
     @language.setter
     def language(self, language):
         if str(language).lower() in self._iso_639_1:
-            self._language = str(language).lower()
+            self.language = str(language).lower()
         elif str(language).lower() in self._translations:
-            self._language = self._translations[str(language).lower()]
+            self.language = self._translations[str(language).lower()]
         else:
             raise Invalid(f"Language: {language} is invalid see Configuration.languages and Configuration.primary_translations for the options.")
 


### PR DESCRIPTION
## Description

Fixed property mismatch between `self._language` and `self.language`

### Issues Fixed or Closed

- Fixes #5 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

## Explanation

TMDb specifies that language defaults to en-US but that is incorrect, it defaults to None/null.

This is reflected correctly in the raw API https://github.com/meisnate12/TMDbAPIs/blob/7f790278b62da0b92da93832f59c01831c82d7a1/tmdbapis/api3.py#L2192-L2195

but not in the object API https://github.com/meisnate12/TMDbAPIs/blob/7f790278b62da0b92da93832f59c01831c82d7a1/tmdbapis/tmdb.py#L61-L84

`self._language` is correctly set to initialize to None, which makes it able to pull from all languages, but the property queried for  the locale to be passed through is `self.language`, which is incorrectly set to initialize to "en"
None is an invalid language, making it impossible to query for backdrops without languages, or query by all languages as seen in #5

also the language getter/setter targeted `_language` which was never queried, instead of `language`